### PR TITLE
TEMPLATE: add ownership and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # Literature Reviews
 
 The goal of this repo is to house markdown documents exploring proposed language and library additions to the Elm language.
+
+## What's a Steward?
+
+A literature review requires a single point of contact, called a steward.
+This person is usually the principal author of the review, but it doesn't have to be.
+They should be willing to answer any issues or questions about their review, and coordinate work on it.
+
+If a literature review is a team effort, this should still be a single person.
+The steward serves as the point person for discussions, and routes questions to the most appropriate venue or person.
+You can list the rest of the team elsewhere in the document for credit's sake, or keep a human-meaningful changelog.

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -1,6 +1,6 @@
 # {Name of Feature}
 
-- Owner: {Your Name} {you@example.com}, {@you} on the Elm Slack
+- Steward: {Your Name} {you@example.com}, {@you} on the Elm Slack
 - Questions + Collaboration: {room} on the Elm Slack
 
 Define your feature. What will you be able to do if it's implemented? Define the main pieces of terminology. If applicable, define what it is *not*.

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -1,4 +1,7 @@
-# <Name of Feature>
+# {Name of Feature}
+
+- Owner: {Your Name} {you@example.com}, {@you} on the Elm Slack
+- Questions + Collaboration: {room} on the Elm Slack
 
 Define your feature. What will you be able to do if it's implemented? Define the main pieces of terminology. If applicable, define what it is *not*.
 
@@ -13,5 +16,5 @@ How do other langues implement this feature or address this problem? Be sure to 
 
 What approachs work well? Which ones do not? Have other communities written design documents or retrospectives on this feature?
 
-## Proposed API or syntaz
+## Proposed API or syntax
 Briefly and provisionally describe a library API or language syntax for the feature. Connect the API with the design goals established above.


### PR DESCRIPTION
A literature review should have a single owner. That's usually the person who originally did the literature review. They should be willing to own it. They should also answer any issues on it with the same SLA expected of other elm-community project owners. And I do mean it should be a *single* owner. If it's a team effort, the team should specify someone to take point for communication. They can list the rest of the team elsewhere in the document for credit's sake, or keep a human-meaningful changelog.

But GitHub issues and PRs are not always the best place for feedback. In that case, the owner should specify their preferred method of communication. Probably something on the Elm Slack, maybe elm-discuss or Reddit. Quick questions and real-time discussion that results in the proposal moving forward should happen in that space.

Also, I fixed some typos. Markdown interprets alphanumeric values inside lt/gt signs as HTML tags so the project title was invisible.