### PR TITLE
Revise use cases section in template

### DIFF
--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -2,19 +2,18 @@
 
 Define your feature. What will you be able to do if it's implemented? Define the main pieces of terminology. If applicable, define what it is *not*.
 
-## Motivation
-Why is this feature useful? Why do you want it in Elm?
-
 ## Current best practice
 Describe the best way(s) of doing what you want to do in Elm today. This can include prose, code snippets, or a link to a working example within this repo. Discuss what makes this situation less than ideal.
 
 ## Use cases from real projects
-Elm features are only added once it's been proven that they solve a problem the occurs in real projects. The more example use cases that are made available the better the final design will be. It's important that these aren't hypothetical scenarios or toy problems, they need to be from real projects that developers are working on.
+Elm isn't designed around hypothetical scenarios or toy problems, but from real projects that developers are working on. Studying multiple use cases ensures that the feature is broadly helpful and fully addresses the problem.
+
+Describe as many real-world use cases as is reasonable. For each, be sure to mention whether it uses the best practice from above or does something else, any constraints or edge cases it requires, and how much it would benefit from the feature.
 
 ## Literature review
-How do other langues implement this feature or address this problem? Be sure to look at other ML-family langues (e.g. Haskell, OCaml, F#) and the JavaScript ecosystem.
+How do other languages implement this feature or address this problem? Be sure to look at other ML-family languages (e.g. Haskell, OCaml, F#) and the JavaScript ecosystem.
 
-What approachs work well? Which ones do not? Have other communities written design documents or retrospectives on this feature?
+What approaches work well? Which ones do not? Have other communities written design documents or retrospectives on this feature?
 
 ## Proposed API or syntaz
 Briefly and provisionally describe a library API or language syntax for the feature. Connect the API with the design goals established above.


### PR DESCRIPTION
Building off #3.

* Remove *Motivation* section. It seems eclipsed by the *Use cases* section.
* Revise the information for the *Use cases* section, and add a more explicit prompt.
* Fix typos.